### PR TITLE
Fixed the '404'/'Unable to connect, please retry' issue.

### DIFF
--- a/cloudprint/cloudprint.py
+++ b/cloudprint/cloudprint.py
@@ -199,7 +199,7 @@ class CloudPrintProxy(object):
     def finish_job(self, job_id):
         r = self.get_rest()
         r.post(
-            PRINT_CLOUD_URL + '/control',
+            PRINT_CLOUD_URL + 'control',
             {
                 'output' : 'json',
                 'jobid': job_id,
@@ -212,7 +212,7 @@ class CloudPrintProxy(object):
     def fail_job(self, job_id):
         r = self.get_rest()
         r.post(
-            PRINT_CLOUD_URL + '/control',
+            PRINT_CLOUD_URL + 'control',
             {
                 'output' : 'json',
                 'jobid': job_id,


### PR DESCRIPTION
The 'control' URL, unlike all the other urls, started with a '/', leading to two slashes (https://google.com/cloudprint//control), which caused a 404, which in turn threw an exception. This leading slash has been removed and 404s are no longer thrown.
