### PR TITLE
Fixed error in daemon mode when no tty available

### DIFF
--- a/cloudprint/cloudprint.py
+++ b/cloudprint/cloudprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import rest
 import platform
 import cups


### PR DESCRIPTION
Be setting stdout/stderr cloudprint works in daemonized mode if not tty is available (initscripts, systemd, upstart, ...)

Fixes issue:
armooo/cloudprint#45
