### PR TITLE
Make saslauthfile name match xmpp_auth_path

### DIFF
--- a/cloudprint/cloudprint.py
+++ b/cloudprint/cloudprint.py
@@ -34,7 +34,7 @@ class CloudPrintProxy(object):
         self.cups= cups.Connection()
         self.proxy =  platform.node() + '-Armooo-PrintProxy'
         self.auth_path = os.path.expanduser('~/.cloudprintauth')
-        self.xmpp_auth_path = os.path.expanduser('~/.cloudprintsaslauth')
+        self.xmpp_auth_path = os.path.expanduser('~/.cloudprintauth.sasl')
         self.username = None
         self.password = None
 


### PR DESCRIPTION
This commit may be seen as an extension or perhaps a tweak of sarumont's commit ( sarumont@725c236 ) . It renames the XMPP SASL auth file to agree with what is already present at line 403.
