### PR TITLE
Ubuntu_etc_init.d

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,3 +39,18 @@ Install
 ::
 
   pip install cloudprint
+
+System setup (Ubuntu /etc/init.d/cloudprint)
+---------------------------------------------------
+
+::
+
+  sudo useradd -d /home/cloudprint cloudprint
+  sudo su - cloudprint
+  mkdir cloudprint
+  cd cloudprint
+  git clone https://github.com/drbitboy/cloudprint.git
+  exit
+  sudo cp ~cloudprint/cloudprint/ubuntu_init_d_cloudprint /etc/init.d/cloudprint
+  sudo update-rc.d cloudprint defaults 99 01
+  sudo reboot

--- a/README.rst
+++ b/README.rst
@@ -45,12 +45,21 @@ System setup (Ubuntu /etc/init.d/cloudprint)
 
 ::
 
-  sudo useradd -d /home/cloudprint cloudprint
-  sudo su - cloudprint
+  sudo su -
+
+  useradd -d /home/cloudprint -m cloudprint
+  apt-get install git python-daemon python-pip python-cups cups-pdf
+
+  su - cloudprint
+
   mkdir cloudprint
-  cd cloudprint
-  git clone https://github.com/drbitboy/cloudprint.git
+  git clone -b ubuntu_etc_init.d https://github.com/drbitboy/cloudprint.git
+  python cloudprint/cloudprint/cloudprint.py
+  Google username: ...@gmail.com 
+  Password: ...
+
   exit
-  sudo cp ~cloudprint/cloudprint/ubuntu_init_d_cloudprint /etc/init.d/cloudprint
-  sudo update-rc.d cloudprint defaults 99 01
-  sudo reboot
+
+  cp -p ~cloudprint/cloudprint/ubuntu_init_d_cloudprint /etc/init.d/cloudprint
+  update-rc.d cloudprint defaults 99 01
+  reboot

--- a/cloudprint/cloudprint.py
+++ b/cloudprint/cloudprint.py
@@ -374,9 +374,10 @@ def wait_for_new_job(sasl_token):
     return msg()
 
 def usage():
-    print sys.argv[0] + ' [-d][-l][-h] [-p pid_file] [-a account_file]'
+    print sys.argv[0] + ' [-d][-l][-w][-h] [-p pid_file] [-a account_file]'
     print '-d\t\t: enable daemon mode (requires the daemon module)'
     print '-l\t\t: logout of the google account'
+    print '-w\t\t: Wait 20s for network resources on startup e.g. from /etc/init.d/ on boot'
     print '-p pid_file\t: path to write the pid to (default cloudprint.pid)'
     print '-a account_file\t: path to google account ident data (default ~/.cloudprintauth)'
     print '\t\t account_file format:\t <Google username>'
@@ -384,9 +385,10 @@ def usage():
     print '-h\t\t: display this help'
 
 def main():
-    opts, args = getopt.getopt(sys.argv[1:], 'dlhp:a:')
+    opts, args = getopt.getopt(sys.argv[1:], 'dlwhp:a:')
     daemon = False
     logout = False
+    doWait = False
     pidfile = None
     authfile = None
     saslauthfile = None
@@ -400,6 +402,8 @@ def main():
         elif o == '-a':
             authfile = a
             saslauthfile = authfile+'.sasl'
+        elif o == '-w':
+            doWait = True
         elif o =='-h':
             usage()
             sys.exit()
@@ -443,6 +447,7 @@ def main():
           cpp.password = getpass.getpass()
 
     #try to login
+    if doWait: time.sleep(20)   ### N.B. A hardcoded timeout is a bad idea!
     while True:
         try:
             sync_printers(cups_connection, cpp)

--- a/ubuntu_init_d_cloudprint
+++ b/ubuntu_init_d_cloudprint
@@ -1,0 +1,93 @@
+#!/bin/bash
+# /etc/init.d/cloudprint
+# Description: Starts the Google Cloud Print script on startup
+# ----------------
+#
+### BEGIN INIT INFO
+# Provides: Cloud-Print
+# Required-Start: $cups $network $local_fs $syslog
+# Required-Stop: $local_fs $syslog
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Description: Start Google Cloud Print
+### END INIT INFO
+
+CPNAME="cloudprint"
+CPUSER="$CPNAME"
+CPHOME="/home/$CPUSER"
+DIR="$CPHOME/$CPNAME/$CPNAME"
+PFX="$DIR/$CPNAME"
+EXE="$PFX.py"
+PIDFILE="$PFX.pid"
+AUTH1="$CPHOME/.${CPNAME}auth"
+AUTH2="$AUTH1.sasl"
+CP_OPTS="-w -d -p $PIDFILE -a $AUTH1"
+QORV=--quiet
+xQORV=--verbose
+
+set -e
+
+elog() {
+  ( /bin/date | tr \\n ' ' ; echo $* ) \
+  1>>/tmp/cloudprint.log 2>>/tmp/cloudprint.err
+}
+
+test -x "$EXE" || exit 0
+test -f "$AUTH1" || exit 0
+test -r "$AUTH1" || exit 0
+test -f "$AUTH2" || exit 0
+test -r "$AUTH2" || exit 0
+( "$EXE" -h 2>&1 | grep -q '/cloudprint.py.*-h' ) 2>/dev/null || exit 0
+
+umask 022
+
+if test -f "/etc/default/$CPNAME"; then
+    . "/etc/default/$CPNAME"
+fi
+
+. /lib/lsb/init-functions
+
+if [ -n "$2" ]; then
+    CP_OPTS="$CP_OPTS $2"
+fi
+
+export PATH="${PATH:+$PATH:}/usr/sbin:/sbin:/usr/bin:/bin"
+
+case "$1" in
+  start)
+	log_daemon_msg "Starting $CPNAME server; options=$CP_OPTS" "$CPNAME" || true
+	if start-stop-daemon --start $QORV --oknodo --chuid "$CPNAME" --group "$CPNAME" --exec "$EXE" -- $CP_OPTS; then
+	    log_end_msg 0 || true
+	else
+	    log_end_msg 1 || true
+	fi
+	;;
+  stop)
+	log_daemon_msg "Stopping $CPNAME server" "$CPNAME" || true
+	if start-stop-daemon --stop $QORV --oknodo --pidfile "$PIDFILE"; then
+	    log_end_msg 0 || true
+	else
+	    log_end_msg 1 || true
+	fi
+	;;
+
+  restart)
+	log_daemon_msg "Restarting $CPNAME server; options=$CP_OPTS" "$CPNAME" || true
+	start-stop-daemon --stop $QORV --oknodo --retry 30 --pidfile "$PIDFILE"
+	if start-stop-daemon --start $QORV --oknodo --chuid "$CPNAME" --group "$CPNAME" --exec "$EXE" -- $CP_OPTS; then
+	    log_end_msg 0 || true
+	else
+	    log_end_msg 1 || true
+	fi
+	;;
+
+  status)
+	status_of_proc -p "$PIDFILE" "$EXE" "$CPNAME" && exit 0 || exit $?
+	;;
+
+  *)
+	log_action_msg "Usage: /etc/init.d/$CPNAME {start|stop|reload|force-reload|restart|try-restart|status}" || true
+	exit 1
+esac
+
+exit 0


### PR DESCRIPTION
I added an optional time.sleep(20) to make it work during system boot using the provided /etc/init.d/cloudprint for ubuntu under a user named cloudprint.  The wait is controlled by the new command-line option -w.

I also added system install instructions to the README to create the user and to start cloudprint during boot.

I believe the problem was that, although the network had started, some resource was not yet available e.g. perhaps resolv.conf was not yet populated with DNS IPs from DHCP; I don't like this approach (a hard-coded timer) but it does work on my laptop and on a clean system using http://instantserver.io/.  
