### PR TITLE
Disable exception processing in XMPP close()

### DIFF
--- a/cloudprint/xmpp.py
+++ b/cloudprint/xmpp.py
@@ -142,12 +142,16 @@ class XmppConnection(object):
 
     def close(self):
         """Close the connection to the XMPP server"""
-        if self._wrappedsock is not None:
+        try:
             self._wrappedsock.shutdown(socket.SHUT_RDWR)
             self._wrappedsock.close()
+        except:
+            # close() is best effort. Don't respond to failures
+            LOGGER.debug("Error encountered closing XMPP socket")
+        finally:
+            self._connected = False
+            self._nextkeepalive = 0
             self._wrappedsock = None
-        self._connected = False
-        self._nextkeepalive = 0
 
 
     def is_connected(self):


### PR DESCRIPTION
When re-establising a lost connection, it was causing an exception
before the XMPP connection is attempted, requiring a restart to
recovery.

Introduced by 16dc1265
Closes davesteele/cloudprint-service#9
