### PR TITLE
xmpp import broke

### DIFF
--- a/cloudprint/cloudprint.py
+++ b/cloudprint/cloudprint.py
@@ -37,7 +37,7 @@ import tempfile
 import time
 import uuid
 
-from cloudprint import xmpp
+import xmpp
 
 
 XMPP_SERVER_HOST = 'talk.google.com'


### PR DESCRIPTION
Would refuse to start with the following error:

```
Traceback (most recent call last):
  File "/opt/cloudprint/cloudprint/cloudprint.py", line 40, in <module>
    from cloudprint import xmpp
  File "/opt/cloudprint/cloudprint/cloudprint.py", line 40, in <module>
    from cloudprint import xmpp
ImportError: cannot import name xmpp
```
Updated code to the proposed, and it's alive!