### PR TITLE
Skip over printers with no PPD when trying to auth for the first time.

### DIFF
--- a/cloudprint/cloudprint.py
+++ b/cloudprint/cloudprint.py
@@ -600,9 +600,18 @@ def main():
         return
 
     if auth.no_auth():
-        name = printers[0]
-        ppd, description = get_printer_info(cups_connection, name)
-        auth.login(name, description, ppd)
+        authed = False
+        for name in printers:
+            try:
+                ppd, description = get_printer_info(cups_connection, name)
+                auth.login(name, description, ppd)
+                authed = True
+                break
+            except (cups.IPPError):
+                LOGGER.error('Unable to login with: ' + name)
+        if not authed:
+            LOGGER.error('Unable to find any valid printer.')
+            return
     else:
         auth.load()
 


### PR DESCRIPTION
If we try to auth with a printer with no PPD, we end up getting:

> cups.IPPError: (1030, u'Not Found')

When we try to call the .ppd endpoint on the CUPS server (getPPD(printer_name)), which causes us to die with a non-useful error message.

With this change we will skip over any printers with no PPD file and auth with the first one that has one, if none are found then exit.

Possibly related to #126 