### PR TITLE
Fix bug in configargparse - sitename

### DIFF
--- a/cloudprint/cloudprint.py
+++ b/cloudprint/cloudprint.py
@@ -534,7 +534,7 @@ def parse_args():
         help='syslog address to use in daemon mode',
     )
     parser.add_argument(
-        '-s',
+        '-s', '--sitename',
         metavar='sitename',
         dest='site',
         default='',


### PR DESCRIPTION
The long form of the 'sitename' option is missing, causing the option to be unavailable from the configuration file.